### PR TITLE
Project carousel usability changes

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -387,6 +387,28 @@ a:focus {
 	margin-left: 15px;
 }
 
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
+  display: block;
+  max-width: 100%;
+  height: 600px;
+  max-height: 600px;
+  margin: 0 auto;
+}
+
+.carousel-indicators li {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin: 1px;
+  text-indent: -999px;
+  cursor: pointer;
+  background-color: #ccc \9;
+  background-color: rgba(0, 0, 0, 0);
+  border: 1px solid #666;
+  border-radius: 10px;
+}
+
 .ctitle {
 	color: {{ site.colors.primary }};
 	font-weight: 700;


### PR DESCRIPTION
Project carousel has gray indicators (visible on white images)
Project carousel centers and resizes images to avoid moving text