### PR TITLE
modernizer is 404ing. doesn't appear to be required.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,6 +27,4 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-
-    <script src="{{ "/assets/js/modernizr.js" | prepend: site.baseurl }}"></script>
 </head>


### PR DESCRIPTION
Hi there. Modernizer isn't included in the assets and so fails to load - the 404 is in your demo site too. 

I've removed it's reference since the site works fine without it.

Alternatively I could have added modernizer's asset but figured less is more and it doesn't seem to be required for bootstrap as far as I can tell

thanks!