### PR TITLE
Removing tags from project.html layout and adding them to each post

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -22,7 +22,7 @@ layout: default
             <p><b>Date:</b> {{ page.date | date: "%b %-d, %Y" }}</p>
             <p><b>Author:</b> {{ page.author }}</p>
             <p><b>Categories:</b> {{ page.categories }}</p>
-            <p><b>Tagged:</b> Flat, UI, Development</p>
+            <p><b>Tagged:</b> {{ page.tagged }}</p>
             <p><b>Client:</b> {{ page.client }}</p>
             <p><b>Website:</b> <a href="{{ page.website }}">{{ page.website }}</a></p>
         </div>

--- a/_posts/project/2014-04-15-your-project-name.markdown
+++ b/_posts/project/2014-04-15-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-16-your-project-name.markdown
+++ b/_posts/project/2014-04-16-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-17-your-project-name.markdown
+++ b/_posts/project/2014-04-17-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-18-your-project-name.markdown
+++ b/_posts/project/2014-04-18-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-19-your-project-name.markdown
+++ b/_posts/project/2014-04-19-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-20-your-project-name.markdown
+++ b/_posts/project/2014-04-20-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-21-your-project-name.markdown
+++ b/_posts/project/2014-04-21-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-22-your-project-name.markdown
+++ b/_posts/project/2014-04-22-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-23-your-project-name.markdown
+++ b/_posts/project/2014-04-23-your-project-name.markdown
@@ -11,6 +11,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---

--- a/_posts/project/2014-04-25-your-project-name.markdown
+++ b/_posts/project/2014-04-25-your-project-name.markdown
@@ -10,6 +10,7 @@ carousel:
 - single01.jpg
 - single02.jpg
 - single03.jpg
+tagged: Flat, UI, Development
 client: Wonder Corp.
 website: http://blacktie.co
 ---


### PR DESCRIPTION
I noticed that the Tags for each post using the project layout seem to be hard-coded into the project layout template (_layouts/project.html). This replaces the hard-coded tags with a variable that can edited on a per-project basis.