### PR TITLE
Add screen-reader alternative text for FontAwesome icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,10 @@
                 <div class="hline-w"></div>
                 <p>
                     {% for network in site.social %}
-                        <a href="{{ network.url }}" class="btn-social btn-outline"><i class="fa fa-{{ network.title }}"></i></a>
+                        <a href="{{ network.url }}" class="btn-social btn-outline">
+                          <i class="fa fa-{{ network.title }}" aria-hidden="true"></i>
+                          <span class="sr-only">{{network.title}}</span>
+                        </a>
                     {% endfor %}
                 </p>
             </div>

--- a/index.html
+++ b/index.html
@@ -8,19 +8,22 @@ permalink: /
     <div class="container">
         <div class="row centered">
             <div class="col-md-4">
-                <i class="fa fa-heart-o"></i>
+                <i class="fa fa-heart-o" aria-hidden="true"></i>
+                <span class="sr-only">An image of a love-heart</span>
                 <h4>Handsomely Crafted</h4>
                 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
                 <p><br/><a href="#" class="btn btn-theme">More Info</a></p>
             </div>
             <div class="col-md-4">
-                <i class="fa fa-flask"></i>
+                <i class="fa fa-flask" aria-hidden="true"></i>
+                <span class="sr-only">An image of a laboratory flask</span>
                 <h4>Retina Ready</h4>
                 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
                 <p><br/><a href="#" class="btn btn-theme">More Info</a></p>
             </div>
             <div class="col-md-4">
-                <i class="fa fa-trophy"></i>
+                <i class="fa fa-trophy" aria-hidden="true"></i>
+                <span class="sr-only">An image of a trophy</span>
                 <h4>Quality Theme</h4>
                 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
                 <p><br/><a href="#" class="btn btn-theme">More Info</a></p>


### PR DESCRIPTION
FontAwesome icons aren't very friendly for screen-readers, because they don't understand how to describe them. In the footer, where FontAwesome icons are used as links with no alternative text, there is no indication to a screen-reader user what the link contains.

This PR hides the FontAwesome icons from screen-readers using `aria-hidden="true"` and adds a screen-reader only description using the Bootstrap `sr-only` class.

I've taken a stab at descriptions for the icons used on the homepage, and generated the alternative text for the footer links automatically using the social-media name.

Tested using VoiceOver for OSX, the rest of the theme seems to work well.
