### PR TITLE
Fix headings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ Solid. A Bootstrap theme for Jekyll.
 
 This is a [Jekyll](http://jekyllrb.com/) port of the [Solid theme](http://www.blacktie.co/2014/05/solid-multipurpose-theme/) by [blacktie.co](http://www.blacktie.co/). Visit the [live demo](https://st4ple.github.io/solid-jekyll/) for a preview. 
 
-##Usage
+## Usage
+
 This theme can be customized, built and published straight from GitHub, thanks to [GitHub Pages](https://pages.github.com/). A local installation of Jekyll isn't even necessary!
 
 [Fork this repository](https://github.com/st4ple/solid-jekyll/fork) to get started. 
-####Customize  
+#### Customize  
 Most general settings and data like site name, colors, address, etc. can be configured and changed right in the main config file: `/_config.yml`
 The content of the Home page can be changed here: `/home.html`
 The content of the About page can be changed here: `/about.html`
 The content of the Portfolio page can be changed here:`/portfolio.html`
 The content of the Contact page can be changed here:`/contact.html`
-####Add content  
+#### Add content  
 Delete the demo content and publish your own content.
-#####Blog post
+##### Blog post
 Create a Blog post by creating a file called `yyyy-mm-dd-name-of-post-like-this.markdown` in the `/_posts/blog/` directory with the following template:
 ```markdown
 ---
@@ -36,7 +37,7 @@ This text will appear in the excerpt "post preview" on the Blog page that lists 
 <!--more-->
 This text will not be shown in the excerpt because it is after the excerpt separator.
 ```
-#####Project post
+##### Project post
 Create a Project post to go in your Portfolio by creating a file called `yyyy-mm-dd-name-of-the-project.markdown` in the `/_posts/project/` directory with the following template:
 ```markdown
 ---
@@ -55,10 +56,10 @@ carousel:
 client: Company XY
 website: http://www.internet.com
 ---
-####This is a heading
+#### This is a heading
 This is a regular paragraph. Write as much as you like.
 ```
-#####Question entry
+##### Question entry
 Create a Question entry (that is listed in the Frequently Asked section on the Home page) in this directory by creating a file called `yyyy-mm-dd-do-i-have-a-question.markdown` in the `/_posts/project/` directory with the following template:
 ```markdown
 ---
@@ -69,14 +70,14 @@ author: First Last
 categories:
 - question            #important: leave this here
 ---
-####Can I use this theme for my website?
+#### Can I use this theme for my website?
 Of course you can!
 ```
-####Publish
+#### Publish
 To publish with [GitHub Pages](https://pages.github.com/), simply create a branch called `gh-pages`in your repository. GitHub will build your site automatically and publish it at `http://yourusername.github.io/repositoryname/`.  
 If there are problems with loading assets like CSS files and images, make sure that the `baseurl` in the `_config.yml`is set correctly (it should say `/repositoryname`).
 
 If you want to host your website somewhere else than GitHub (or just would like to customize and build your site locally), please check out the [Jekyll documentation](http://jekyllrb.com/). 
 
-##License
+## License
 This theme is licensed under [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
Fix the README file's headings so they render as proper HTML.

See also #38. This pull request does not fix that, only the way the README file is rendered.